### PR TITLE
Resource allocation updated via module.config

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -20,6 +20,9 @@ process {
 
     withName: FASTQC {
         ext.args = '--quiet'
+        cpus   = { check_max( 6 * task.attempt, 'cpus' ) }
+        memory = { check_max( 36.GB * task.attempt, 'memory' ) }
+        time   = { check_max( 8.h * task.attempt, 'time' ) }
     }
 
     withName: 'MULTIQC' {


### PR DESCRIPTION
Updated`module.config` file to include new parameters for FastQC: cpus = { check_max( 6 * task.attempt, 'cpus' ) } memory = { check_max( 36.GB * task.attempt, 'memory' ) } time = { check_max( 8.h * task.attempt, 'time' ) }

Script was validated to run with `test.config` computational limits. We were unable to run FastQC without respective `.fastq` files, so we cannot validate the computational limits set on FastQC. Furthermore, this change was performed on an M1 MacBook Air, which lacks the capacity required to test these limits. HPC is required to validate compute limits defined in config file.